### PR TITLE
Bump cx_Freeze to v. 7.2.1, add more tags

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -23,7 +23,8 @@ on:
       - '3.11-windowsservercore-1809.Dockerfile'
       - './github/workflows/docker_image.yml'
 env:
-  CX_FREEZE_VERSION: '7.2.0'
+  CX_FREEZE_VERSION_MINOR: '7.2'
+  CX_FREEZE_VERSION_PATCH: '1'
   PYTHON_VERSION_MAJOR: '3.11'
   PYTHON_VERSION_MINOR: '9'
   WINDOWS_VERSION: 'windowsservercore-1809'
@@ -44,17 +45,27 @@ jobs:
           --quiet
           --platform windows/amd64
           -t ${{ env.DOCKERHUB_REPO }}:latest
-          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION }}
-          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}
-          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}-${{ env.WINDOWS_VERSION }}
-          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}
-          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}-${{ env.WINDOWS_VERSION }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MAJOR }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MAJOR }}-${{ env.WINDOWS_VERSION }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}-${{ env.WINDOWS_VERSION }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MAJOR }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MAJOR }}-${{ env.WINDOWS_VERSION }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}
+          -t ${{ env.DOCKERHUB_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}-${{ env.WINDOWS_VERSION }}
           -t ${{ env.GHCR_REPO }}:latest
-          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION }}
-          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}
-          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}-${{ env.WINDOWS_VERSION }}
-          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}
-          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}-${{ env.WINDOWS_VERSION }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MAJOR }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MAJOR }}-${{ env.WINDOWS_VERSION }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}-${{ env.WINDOWS_VERSION }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MAJOR }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MAJOR }}-${{ env.WINDOWS_VERSION }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}
+          -t ${{ env.GHCR_REPO }}:${{ env.CX_FREEZE_VERSION_MINOR }}.${{ env.CX_FREEZE_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}-${{ env.WINDOWS_VERSION }}
           -f ${{ env.PYTHON_VERSION_MAJOR }}-${{ env.WINDOWS_VERSION }}.Dockerfile
           .
       - name: Test the built image

--- a/3.11-windowsservercore-1809.Dockerfile
+++ b/3.11-windowsservercore-1809.Dockerfile
@@ -10,9 +10,9 @@
 
 FROM python:3.11-windowsservercore-1809@sha256:6c579f77d1b9407bebde36ce0d345cc576b6ffa5e6e75538517c7b50171258f0 AS install
 WORKDIR c:\\
-RUN powershell -Command "Invoke-WebRequest https://github.com/marcelotduarte/cx_Freeze/archive/e275be9de14bc276c6f541efd9e226007009a3e9.zip -OutFile cxfreeze.zip"
+RUN powershell -Command "Invoke-WebRequest https://github.com/marcelotduarte/cx_Freeze/archive/31492a8edea6f459cce301aaae56d462c3192d8c.zip -OutFile cxfreeze.zip"
 RUN powershell -Command "Expand-Archive cxfreeze.zip cxfreeze"
-RUN python -m pip install --disable-pip-version-check ./cxfreeze/cx_Freeze-e275be9de14bc276c6f541efd9e226007009a3e9/
+RUN python -m pip install --disable-pip-version-check ./cxfreeze/cx_Freeze-31492a8edea6f459cce301aaae56d462c3192d8c/
 
 FROM python:3.11-windowsservercore-1809@sha256:6c579f77d1b9407bebde36ce0d345cc576b6ffa5e6e75538517c7b50171258f0
 COPY --from=install c:\\Python c:\\Python\\


### PR DESCRIPTION
Bumps cx_Freeze version in images to 7.2.1, released on 11-09-2024: https://github.com/marcelotduarte/cx_Freeze/releases/tag/7.2.1

Also fixes naming of version components and adds separate tags for minor and patch versions.