### PR TITLE
Bump cx_Freeze to v. 7.2.3

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -24,7 +24,7 @@ on:
       - './github/workflows/docker_image.yml'
 env:
   CX_FREEZE_VERSION_MINOR: '7.2'
-  CX_FREEZE_VERSION_PATCH: '2'
+  CX_FREEZE_VERSION_PATCH: '3'
   PYTHON_VERSION_MAJOR: '3.11'
   PYTHON_VERSION_MINOR: '9'
   WINDOWS_VERSION: 'windowsservercore-1809'

--- a/3.11-windowsservercore-1809.Dockerfile
+++ b/3.11-windowsservercore-1809.Dockerfile
@@ -10,9 +10,9 @@
 
 FROM python:3.11-windowsservercore-1809@sha256:6c579f77d1b9407bebde36ce0d345cc576b6ffa5e6e75538517c7b50171258f0 AS install
 WORKDIR c:\\
-RUN powershell -Command "Invoke-WebRequest https://github.com/marcelotduarte/cx_Freeze/archive/e752750b374064eb298399d647fa26870e5ba1c6.zip -OutFile cxfreeze.zip"
+RUN powershell -Command "Invoke-WebRequest https://github.com/marcelotduarte/cx_Freeze/archive/7a1ef98d38b60e127c17a1ea0a6fd6eac75b1071.zip -OutFile cxfreeze.zip"
 RUN powershell -Command "Expand-Archive cxfreeze.zip cxfreeze"
-RUN python -m pip install --disable-pip-version-check ./cxfreeze/cx_Freeze-e752750b374064eb298399d647fa26870e5ba1c6/
+RUN python -m pip install --disable-pip-version-check ./cxfreeze/cx_Freeze-7a1ef98d38b60e127c17a1ea0a6fd6eac75b1071/
 
 FROM python:3.11-windowsservercore-1809@sha256:6c579f77d1b9407bebde36ce0d345cc576b6ffa5e6e75538517c7b50171258f0
 COPY --from=install c:\\Python c:\\Python\\


### PR DESCRIPTION
Bumps cx_Freeze version in images to 7.2.3, released on 03-10-2024: https://github.com/marcelotduarte/cx_Freeze/releases/tag/7.2.3