### PR TITLE
Trigger build on workflow file push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ on:
       - 'main'
     paths:
       - '3.11-windowsservercore-1809.Dockerfile'
+      - '.github/workflows/docker.yml'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Adds GH Actions workflow file to paths triggering build workflow on push event to `main`.