### PR TITLE
Update actions/checkout to v. 4.2.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           persist-credentials: false
       - name: Build Docker image


### PR DESCRIPTION
Updates actions/checkout GH Action to version 4.2.2, released on 23-10-2024. This release improves support for well-known environment variables, which may prove useful.