### PR TITLE
Update cx_Freeze to v. 8.0.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,8 @@ on:
       - '3.12-windowsservercore-1809.Dockerfile'
       - '.github/workflows/docker.yml'
 env:
-  CX_FREEZE_VERSION_MINOR: '7.2'
-  CX_FREEZE_VERSION_PATCH: '10'
+  CX_FREEZE_VERSION_MINOR: '8.0'
+  CX_FREEZE_VERSION_PATCH: '0'
   PYTHON_VERSION_MAJOR: '3.12'
   PYTHON_VERSION_MINOR: '9'
   WINDOWS_VERSION: 'windowsservercore-1809'

--- a/3.12-windowsservercore-1809.Dockerfile
+++ b/3.12-windowsservercore-1809.Dockerfile
@@ -9,7 +9,7 @@
 # If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 FROM python:3.12-windowsservercore-1809@sha256:828cd05029317faa1c3e4ed79dabbb955416009b8588112f6078579ebb0b9d96
-ARG CX_FREEZE_COMMIT_SHA=5741131d381b9d77550e838806bb79a3b2bc6d1e
+ARG CX_FREEZE_COMMIT_SHA=d8e990bd975f56c73ede3b0e42102e201c901ba3
 RUN mkdir c:\\Users\\ContainerUser\\SourceCode
 WORKDIR c:\\
 RUN powershell -Command " \


### PR DESCRIPTION
Updates cx_Freeze to version 8.0.0, released on 2025-03-21.