### PR TITLE
Update the Python image to newest version

### DIFF
--- a/3.12-windowsservercore-1809.Dockerfile
+++ b/3.12-windowsservercore-1809.Dockerfile
@@ -8,7 +8,7 @@
 # You should have received a copy of the CC0 Public Domain Dedication along with this software.
 # If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
-FROM python:3.12-windowsservercore-1809@sha256:828cd05029317faa1c3e4ed79dabbb955416009b8588112f6078579ebb0b9d96
+FROM python:3.12-windowsservercore-1809@sha256:89b7c9252225dcd7e365cc1ef32d81382e206a84892a8bfc0c348f71337604b2
 ARG CX_FREEZE_COMMIT_SHA=f94dde3947144cbca99d7ffba4578aeef4de6656
 RUN mkdir c:\\Users\\ContainerUser\\SourceCode
 WORKDIR c:\\


### PR DESCRIPTION
Updates the base Python image to newest available version for 3.12-windowsservercore-1809. This will likely be the last base image, as this tag is now delisted from [Python's page on Docker Hub](https://hub.docker.com/_/python).