### PR TITLE
Update base Python image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - 'main'
     paths:
-      - '3.12-windowsservercore-1809.Dockerfile'
+      - '3.13-windowsservercore-ltsc2022.Dockerfile'
       - '.github/workflows/docker.yml'
   pull_request:
     types:
@@ -21,20 +21,20 @@ on:
       - ready_for_review
       - reopened
     paths:
-      - '3.12-windowsservercore-1809.Dockerfile'
+      - '3.13-windowsservercore-ltsc2022.Dockerfile'
       - '.github/workflows/docker.yml'
 env:
   CX_FREEZE_VERSION_MINOR: '8.1'
   CX_FREEZE_VERSION_PATCH: '0'
-  PYTHON_VERSION_MAJOR: '3.12'
+  PYTHON_VERSION_MAJOR: '3.13'
   PYTHON_VERSION_MINOR: '9'
-  WINDOWS_VERSION: 'windowsservercore-1809'
+  WINDOWS_VERSION: 'windowsservercore-ltsc2022'
   DOCKERHUB_REPO: ${{ vars.DOCKERHUB_USERNAME }}/cx-freeze
   GHCR_REPO: ghcr.io/${{ github.repository }}
   DOCKER_CACHE_PATH: C:\ProgramData\Docker\windowsfilter
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2

--- a/3.13-windowsservercore-ltsc2022.Dockerfile
+++ b/3.13-windowsservercore-ltsc2022.Dockerfile
@@ -8,12 +8,11 @@
 # You should have received a copy of the CC0 Public Domain Dedication along with this software.
 # If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
-FROM python:3.12-windowsservercore-1809@sha256:828cd05029317faa1c3e4ed79dabbb955416009b8588112f6078579ebb0b9d96
+FROM python:3.13-windowsservercore-ltsc2022@sha256:6d8bb9195200234491174373e597e0b8c5468694c77ed06dcdb45c04a5770171
 ARG CX_FREEZE_COMMIT_SHA=f94dde3947144cbca99d7ffba4578aeef4de6656
 RUN mkdir c:\\Users\\ContainerUser\\SourceCode
 WORKDIR c:\\
 RUN powershell -Command " \
-	$ErrorActionPreference = 'Stop'; \
 	Invoke-WebRequest https://github.com/marcelotduarte/cx_Freeze/archive/$Env:CX_FREEZE_COMMIT_SHA.zip -OutFile cxfreeze.zip; \
 	Expand-Archive cxfreeze.zip cx_Freeze-$Env:CX_FREEZE_COMMIT_SHA; \
 	Remove-Item -Path cxfreeze.zip; \

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ docker-cx-freeze
 ================
 This repository holds configuration for building `Python's Docker image`_
 with `cx_Freeze`_ installed. Currently it supports only the
-``3.12-windowsservercore-1809`` platform.
+``3.13-windowsservercore-ltsc2022`` platform.
 
 Download
 ========
@@ -32,7 +32,7 @@ via the context menu on it's system tray icon.
 After completing these steps, clone this repository, open the Windows
 command line program in it's directory and execute::
 
-  docker build -t cx-freeze:latest -f 3.12-windowsservercore-1809.Dockerfile .
+  docker build -t cx-freeze:latest -f 3.13-windowsservercore-ltsc2022.Dockerfile .
 
 This will create an image tagged ``cx-freeze:latest`` in your local Docker image
 store. You can change this tag name to whatever you like, as long as it
@@ -47,7 +47,7 @@ to answer. However, there is genuine intent of providing support on a
 best effort basis.
 
 If you or your company require more commitment, you can inquire about
-paid support at ``13271065+hbielenia@users.noreply.github.com``.
+paid support at ``hbielenia@users.noreply.github.com``.
 
 Copyright
 =========


### PR DESCRIPTION
Updates the base Python image to v. 3.13.9 and the underlying Windows Server Core image to ltsc 2022.