### PR TITLE
Update cx_Freeze to v. 8.3.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ on:
       - '3.13-windowsservercore-ltsc2022.Dockerfile'
       - '.github/workflows/docker.yml'
 env:
-  CX_FREEZE_VERSION_MINOR: '8.2'
+  CX_FREEZE_VERSION_MINOR: '8.3'
   CX_FREEZE_VERSION_PATCH: '0'
   PYTHON_VERSION_MAJOR: '3.13'
   PYTHON_VERSION_MINOR: '9'

--- a/3.13-windowsservercore-ltsc2022.Dockerfile
+++ b/3.13-windowsservercore-ltsc2022.Dockerfile
@@ -9,7 +9,7 @@
 # If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 FROM python:3.13-windowsservercore-ltsc2022@sha256:6d8bb9195200234491174373e597e0b8c5468694c77ed06dcdb45c04a5770171
-ARG CX_FREEZE_COMMIT_SHA=88a696146d250b8d9d5e994f7840349911902b3c
+ARG CX_FREEZE_COMMIT_SHA=d1ae221d46dcb09be85c9e3e481b27793b9f7ce9
 RUN mkdir c:\\Users\\ContainerUser\\SourceCode
 WORKDIR c:\\
 RUN powershell -Command " \


### PR DESCRIPTION
Updates cx_Freeze to v. 8.3.0, released on 2025-05-12.