### PR TITLE
Update cx_Freeze to v. 8.4.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ on:
       - '.github/workflows/docker.yml'
 env:
   CX_FREEZE_VERSION_MINOR: '8.4'
-  CX_FREEZE_VERSION_PATCH: '0'
+  CX_FREEZE_VERSION_PATCH: '1'
   PYTHON_VERSION_MAJOR: '3.13'
   PYTHON_VERSION_MINOR: '9'
   WINDOWS_VERSION: 'windowsservercore-ltsc2022'

--- a/3.13-windowsservercore-ltsc2022.Dockerfile
+++ b/3.13-windowsservercore-ltsc2022.Dockerfile
@@ -9,7 +9,7 @@
 # If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 FROM python:3.13-windowsservercore-ltsc2022@sha256:6d8bb9195200234491174373e597e0b8c5468694c77ed06dcdb45c04a5770171
-ARG CX_FREEZE_COMMIT_SHA=83669dc59a222e2da261af02aac954a0604cc6df
+ARG CX_FREEZE_COMMIT_SHA=c33f4df63a03bfcff3366a30e3c24879d5defb1f
 RUN mkdir c:\\Users\\ContainerUser\\SourceCode
 WORKDIR c:\\
 RUN powershell -Command " \


### PR DESCRIPTION
Updates cx_Freeze to version 8.4.1, released on 2025-09-20.